### PR TITLE
Fix #56 - Add versioning to test_connection and test_auth

### DIFF
--- a/homepilot/api.py
+++ b/homepilot/api.py
@@ -43,23 +43,35 @@ class HomePilotApi:
                 if response.status != 200:
                     response = await session.get(f"http://{host}/hp/devices/0")
                     if response.status != 200:
-                        return "error"
-                    return "ok_v2"
+                        if response.status != 401:
+                            return "error"
+                        # Otherwise try for login requirements
+                    else:
+                        return "ok_v2"
+
                 response = await session.post(
                     f"http://{host}/authentication/password_salt"
                 )
                 if response.status == 500:
                     return "ok"
                 else:
+                    if response.status == 401:
+                        response = await session.post(
+                            f"http://{host}/hp/authentication/password_salt"
+                        )
+                        if response.status == 200:
+                            return "auth_required_v2"
+                        else:
+                            return "error"
                     return "auth_required"
             except ClientConnectorError:
                 return "error"
 
     @staticmethod
-    async def test_auth(host: str, password: str) -> AbstractCookieJar:
+    async def test_auth(host: str, password: str, base_path: str = "") -> AbstractCookieJar:
         cookie_jar = aiohttp.CookieJar(unsafe=True)
         async with aiohttp.ClientSession(cookie_jar=cookie_jar) as session:
-            response = await session.post(f"http://{host}/authentication/password_salt")
+            response = await session.post(f"http://{host}{base_path}/authentication/password_salt")
             response_data = await response.json()
             if response.status == 500 and response_data["error_code"] == 5007:
                 raise AuthError()
@@ -71,7 +83,7 @@ class HomePilotApi:
                 f"{salt}{hashed_password}".encode("utf-8")
             ).hexdigest()
             response = await session.post(
-                f"http://{host}/authentication/login",
+                f"http://{host}{base_path}/authentication/login",
                 json={"password": salted_password, "password_salt": salt},
             )
             if response.status != 200:
@@ -80,7 +92,7 @@ class HomePilotApi:
 
     async def authenticate(self):
         if not self.authenticated and self.password != "":
-            self.cookie_jar = await HomePilotApi.test_auth(self.host, self.password)
+            self.cookie_jar = await HomePilotApi.test_auth(self.host, self.password, self._base_path)
             self._authenticated = True
 
     async def get_devices(self):

--- a/homepilot/api.py
+++ b/homepilot/api.py
@@ -33,7 +33,7 @@ class HomePilotApi:
         self._host = host
         self._password = password
         self._api_version = api_version
-        self._base_path = "/hp" if api_version == 2 else ""
+        self._base_path = HomePilotApi.get_base_path(api_version)
 
     @staticmethod
     async def test_connection(host: str) -> str:
@@ -68,8 +68,16 @@ class HomePilotApi:
                 return "error"
 
     @staticmethod
-    async def test_auth(host: str, password: str, base_path: str = "") -> AbstractCookieJar:
+    def get_base_path(api_version) -> str:
+        if api_version == 2:
+            return "/hp"
+        else:
+            return ""
+
+    @staticmethod
+    async def test_auth(host: str, password: str, api_version: int = 1) -> AbstractCookieJar:
         cookie_jar = aiohttp.CookieJar(unsafe=True)
+        base_path = HomePilotApi.get_base_path(api_version)
         async with aiohttp.ClientSession(cookie_jar=cookie_jar) as session:
             response = await session.post(f"http://{host}{base_path}/authentication/password_salt")
             response_data = await response.json()

--- a/homepilot/api.py
+++ b/homepilot/api.py
@@ -100,7 +100,7 @@ class HomePilotApi:
 
     async def authenticate(self):
         if not self.authenticated and self.password != "":
-            self.cookie_jar = await HomePilotApi.test_auth(self.host, self.password, self._base_path)
+            self.cookie_jar = await HomePilotApi.test_auth(self.host, self.password, self.api_version)
             self._authenticated = True
 
     async def get_devices(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyrademacher",
-    version="0.13.2",
+    version="0.13.3",
     author="Pedro Ribeiro",
     author_email="pedroeusebio@gmail.com",
     description="Control devices connected to your Rademacher Homepilot "

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyrademacher",
-    version="0.13.4",
+    version="0.13.5",
     author="Pedro Ribeiro",
     author_email="pedroeusebio@gmail.com",
     description="Control devices connected to your Rademacher Homepilot "

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyrademacher",
-    version="0.13.3",
+    version="0.13.4",
     author="Pedro Ribeiro",
     author_email="pedroeusebio@gmail.com",
     description="Control devices connected to your Rademacher Homepilot "


### PR DESCRIPTION
Allows API-version to be applied to test_connection and test_auth as this was moved into subpath /hp as well.
Defaults to previous behavior but enables to provide an API-version to both static methods.
homeassistant-rademacher should be updated to make use of the change as well so the API-version can be used on the static method calls too.