### PR TITLE
Open fixture with UTF-8 encoding to fix test on Windows

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -10,7 +10,7 @@ from homepilot.switch import HomePilotSwitch
 class TestHomePilotSwitch:
     @pytest.fixture
     def mocked_api(self):
-        f = open("tests/test_files/device_switch.json")
+        f = open("tests/test_files/device_switch.json", encoding="utf-8")
         j = json.load(f)
         api = MagicMock()
         func_get_device = asyncio.Future()


### PR DESCRIPTION
This fixes a wrong encoding when reading the fixture file for `test_switch.py`, which leads to a failing test:

```
E AssertionError: assert 'HÃ¼tte' == 'Hütte'
E
E - Hütte
E + HÃ¼tte
```