### PR TITLE
Feat/auto config device commands

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,8 +29,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest aioresponses pytest-mock pytest-asyncio==1.3.0
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        # aioresponses is not yet compatible with aiohttp>=3.14
-        python -m pip install "aiohttp<3.14"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest aioresponses pytest-mock pytest-asyncio
+        # pytest-asyncio pinned: 1.x removes the implicit event loop the
+        # existing sync fixtures rely on (asyncio.Future()).
+        python -m pip install flake8 pytest "pytest-asyncio==0.21.2" aioresponses pytest-mock
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # aioresponses is not yet compatible with aiohttp>=3.14
+        python -m pip install "aiohttp<3.14"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ These devices also support the auto modes (`has_*_auto_mode` / `*_auto_mode_valu
 `async_set_*_auto_mode(...)`) for `auto`, `time`, `contact`, `wind`, `dawn`, `dusk`,
 `rain` and `sun`.
 
+They additionally expose the read-only weather program "active" states for devices
+that advertise the corresponding event — `has_sun_prog_active` / `sun_prog_active_value`,
+`has_wind_prog_active` / `wind_prog_active_value` and `has_rain_prog_active` /
+`rain_prog_active_value` — updated on every state refresh.
+
 ### Scene Management
 
 The library supports managing HomePilot scenes with comprehensive functionality:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ print(manager.devices["-1"].fw_version) # ID -1 is reserved for the hub itself
 ```
 Each device in manager.devices is an instance of the specific device class.
 
+### Auto Config Devices: Commands
+
+Every device that inherits from `HomePilotAutoConfigDevice` (covers, switches/actuators,
+thermostats, lights) exposes the weather and contact commands that the hub advertises for
+that device. Each command has a capability flag (`has_*_cmd`) and an awaitable method that
+is a no-op when the capability is missing:
+
+| Command | Capability flag | Method |
+| --- | --- | --- |
+| Sun start / stop | `has_sun_start_cmd` / `has_sun_stop_cmd` | `async_sun_start_cmd()` / `async_sun_stop_cmd()` |
+| Wind start / stop | `has_wind_start_cmd` / `has_wind_stop_cmd` | `async_wind_start_cmd()` / `async_wind_stop_cmd()` |
+| Rain start / stop | `has_rain_start_cmd` / `has_rain_stop_cmd` | `async_rain_start_cmd()` / `async_rain_stop_cmd()` |
+| Go to dawn / dusk position | `has_goto_dawn_pos_cmd` / `has_goto_dusk_pos_cmd` | `async_goto_dawn_pos_cmd()` / `async_goto_dusk_pos_cmd()` |
+| Contact open / close | `has_contact_open_cmd` / `has_contact_close_cmd` | `async_contact_open_cmd()` / `async_contact_close_cmd()` |
+
+```python
+device = manager.devices["1"]
+
+if device.has_sun_start_cmd:
+    await device.async_sun_start_cmd()   # trigger the sun command
+
+if device.has_contact_open_cmd:
+    await device.async_contact_open_cmd()
+```
+
+These devices also support the auto modes (`has_*_auto_mode` / `*_auto_mode_value` /
+`async_set_*_auto_mode(...)`) for `auto`, `time`, `contact`, `wind`, `dawn`, `dusk`,
+`rain` and `sun`.
+
 ### Scene Management
 
 The library supports managing HomePilot scenes with comprehensive functionality:

--- a/homepilot/cover.py
+++ b/homepilot/cover.py
@@ -15,9 +15,6 @@ from .const import (
     APICAP_VERSION_CFG,
     APICAP_VENTIL_POS_CFG,
     APICAP_VENTIL_POS_MODE_CFG,
-    APICAP_SUN_PROG_ACTIVE_EVT,
-    APICAP_WIND_PROG_ACTIVE_EVT,
-    APICAP_RAIN_PROG_ACTIVE_EVT,
     SUPPORTED_DEVICES,
 )
 from .api import HomePilotApi
@@ -47,12 +44,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
     _blocking_detection_status: bool
     _has_obstacle_detection: bool
     _obstacle_detection_status: bool
-    _has_sun_prog_active: bool
-    _sun_prog_active_value: bool
-    _has_wind_prog_active: bool
-    _wind_prog_active_value: bool
-    _has_rain_prog_active: bool
-    _rain_prog_active_value: bool
 
     def __init__(
         self,
@@ -72,9 +63,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         has_ventilation_position_config: bool = False,
         has_blocking_detection: bool = False,
         has_obstacle_detection: bool = False,
-        has_sun_prog_active: bool = False,
-        has_wind_prog_active: bool = False,
-        has_rain_prog_active: bool = False,
         device_map: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(
@@ -96,9 +84,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         self._has_ventilation_position_config = has_ventilation_position_config
         self._has_blocking_detection = has_blocking_detection
         self._has_obstacle_detection = has_obstacle_detection
-        self._has_sun_prog_active = has_sun_prog_active
-        self._has_wind_prog_active = has_wind_prog_active
-        self._has_rain_prog_active = has_rain_prog_active
 
     @staticmethod
     def build_from_api(api: HomePilotApi, did: str):
@@ -131,9 +116,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
             has_ventilation_position_config=APICAP_VENTIL_POS_MODE_CFG in device_map,
             has_blocking_detection=APICAP_BLOCK_DET_EVT in device_map,
             has_obstacle_detection=APICAP_OBSTACLE_DET_EVT in device_map,
-            has_sun_prog_active=APICAP_SUN_PROG_ACTIVE_EVT in device_map,
-            has_wind_prog_active=APICAP_WIND_PROG_ACTIVE_EVT in device_map,
-            has_rain_prog_active=APICAP_RAIN_PROG_ACTIVE_EVT in device_map,
             device_map=device_map,
         )
 
@@ -160,13 +142,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
             self.blocking_detection_status = device_map[APICAP_BLOCK_DET_EVT]["value"] == "true"
         if self.has_obstacle_detection:
             self.obstacle_detection_status = device_map[APICAP_OBSTACLE_DET_EVT]["value"] == "true"
-        # Update new program active properties
-        if self.has_sun_prog_active:
-            self.sun_prog_active_value = device_map[APICAP_SUN_PROG_ACTIVE_EVT]["value"] == "true"
-        if self.has_wind_prog_active:
-            self.wind_prog_active_value = device_map[APICAP_WIND_PROG_ACTIVE_EVT]["value"] == "true"
-        if self.has_rain_prog_active:
-            self.rain_prog_active_value = device_map[APICAP_RAIN_PROG_ACTIVE_EVT]["value"] == "true"
 
     async def async_open_cover(self) -> None:
         await self.api.async_open_cover(self.did)
@@ -320,40 +295,3 @@ class HomePilotCover(HomePilotAutoConfigDevice):
     @obstacle_detection_status.setter
     def obstacle_detection_status(self, obstacle_detection_status):
         self._obstacle_detection_status = obstacle_detection_status
-
-    # New program active properties
-    @property
-    def has_sun_prog_active(self) -> bool:
-        return self._has_sun_prog_active
-
-    @property
-    def sun_prog_active_value(self) -> bool:
-        return self._sun_prog_active_value
-
-    @sun_prog_active_value.setter
-    def sun_prog_active_value(self, sun_prog_active_value):
-        self._sun_prog_active_value = sun_prog_active_value
-
-    @property
-    def has_wind_prog_active(self) -> bool:
-        return self._has_wind_prog_active
-
-    @property
-    def wind_prog_active_value(self) -> bool:
-        return self._wind_prog_active_value
-
-    @wind_prog_active_value.setter
-    def wind_prog_active_value(self, wind_prog_active_value):
-        self._wind_prog_active_value = wind_prog_active_value
-
-    @property
-    def has_rain_prog_active(self) -> bool:
-        return self._has_rain_prog_active
-
-    @property
-    def rain_prog_active_value(self) -> bool:
-        return self._rain_prog_active_value
-
-    @rain_prog_active_value.setter
-    def rain_prog_active_value(self, rain_prog_active_value):
-        self._rain_prog_active_value = rain_prog_active_value

--- a/homepilot/cover.py
+++ b/homepilot/cover.py
@@ -15,14 +15,6 @@ from .const import (
     APICAP_VERSION_CFG,
     APICAP_VENTIL_POS_CFG,
     APICAP_VENTIL_POS_MODE_CFG,
-    APICAP_SUN_START_CMD,
-    APICAP_SUN_STOP_CMD,
-    APICAP_WIND_START_CMD,
-    APICAP_WIND_STOP_CMD,
-    APICAP_RAIN_START_CMD,
-    APICAP_RAIN_STOP_CMD,
-    APICAP_GOTO_DAWN_POS_CMD,
-    APICAP_GOTO_DUSK_POS_CMD,
     APICAP_SUN_PROG_ACTIVE_EVT,
     APICAP_WIND_PROG_ACTIVE_EVT,
     APICAP_RAIN_PROG_ACTIVE_EVT,
@@ -55,14 +47,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
     _blocking_detection_status: bool
     _has_obstacle_detection: bool
     _obstacle_detection_status: bool
-    _has_sun_start_cmd: bool
-    _has_sun_stop_cmd: bool
-    _has_wind_start_cmd: bool
-    _has_wind_stop_cmd: bool
-    _has_rain_start_cmd: bool
-    _has_rain_stop_cmd: bool
-    _has_goto_dawn_pos_cmd: bool
-    _has_goto_dusk_pos_cmd: bool
     _has_sun_prog_active: bool
     _sun_prog_active_value: bool
     _has_wind_prog_active: bool
@@ -88,14 +72,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         has_ventilation_position_config: bool = False,
         has_blocking_detection: bool = False,
         has_obstacle_detection: bool = False,
-        has_sun_start_cmd: bool = False,
-        has_sun_stop_cmd: bool = False,
-        has_wind_start_cmd: bool = False,
-        has_wind_stop_cmd: bool = False,
-        has_rain_start_cmd: bool = False,
-        has_rain_stop_cmd: bool = False,
-        has_goto_dawn_pos_cmd: bool = False,
-        has_goto_dusk_pos_cmd: bool = False,
         has_sun_prog_active: bool = False,
         has_wind_prog_active: bool = False,
         has_rain_prog_active: bool = False,
@@ -120,14 +96,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         self._has_ventilation_position_config = has_ventilation_position_config
         self._has_blocking_detection = has_blocking_detection
         self._has_obstacle_detection = has_obstacle_detection
-        self._has_sun_start_cmd = has_sun_start_cmd
-        self._has_sun_stop_cmd = has_sun_stop_cmd
-        self._has_wind_start_cmd = has_wind_start_cmd
-        self._has_wind_stop_cmd = has_wind_stop_cmd
-        self._has_rain_start_cmd = has_rain_start_cmd
-        self._has_rain_stop_cmd = has_rain_stop_cmd
-        self._has_goto_dawn_pos_cmd = has_goto_dawn_pos_cmd
-        self._has_goto_dusk_pos_cmd = has_goto_dusk_pos_cmd
         self._has_sun_prog_active = has_sun_prog_active
         self._has_wind_prog_active = has_wind_prog_active
         self._has_rain_prog_active = has_rain_prog_active
@@ -163,14 +131,6 @@ class HomePilotCover(HomePilotAutoConfigDevice):
             has_ventilation_position_config=APICAP_VENTIL_POS_MODE_CFG in device_map,
             has_blocking_detection=APICAP_BLOCK_DET_EVT in device_map,
             has_obstacle_detection=APICAP_OBSTACLE_DET_EVT in device_map,
-            has_sun_start_cmd=APICAP_SUN_START_CMD in device_map,
-            has_sun_stop_cmd=APICAP_SUN_STOP_CMD in device_map,
-            has_wind_start_cmd=APICAP_WIND_START_CMD in device_map,
-            has_wind_stop_cmd=APICAP_WIND_STOP_CMD in device_map,
-            has_rain_start_cmd=APICAP_RAIN_START_CMD in device_map,
-            has_rain_stop_cmd=APICAP_RAIN_STOP_CMD in device_map,
-            has_goto_dawn_pos_cmd=APICAP_GOTO_DAWN_POS_CMD in device_map,
-            has_goto_dusk_pos_cmd=APICAP_GOTO_DUSK_POS_CMD in device_map,
             has_sun_prog_active=APICAP_SUN_PROG_ACTIVE_EVT in device_map,
             has_wind_prog_active=APICAP_WIND_PROG_ACTIVE_EVT in device_map,
             has_rain_prog_active=APICAP_RAIN_PROG_ACTIVE_EVT in device_map,
@@ -239,38 +199,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         if self.has_tilt:
             await self.api.async_stop_cover_tilt(self.did)
 
-    # New weather program commands
-    async def async_sun_start_cmd(self) -> None:
-        if self.has_sun_start_cmd:
-            await self.api.async_sun_start_cmd(self.did)
-
-    async def async_sun_stop_cmd(self) -> None:
-        if self.has_sun_stop_cmd:
-            await self.api.async_sun_stop_cmd(self.did)
-
-    async def async_wind_start_cmd(self) -> None:
-        if self.has_wind_start_cmd:
-            await self.api.async_wind_start_cmd(self.did)
-
-    async def async_wind_stop_cmd(self) -> None:
-        if self.has_wind_stop_cmd:
-            await self.api.async_wind_stop_cmd(self.did)
-
-    async def async_rain_start_cmd(self) -> None:
-        if self.has_rain_start_cmd:
-            await self.api.async_rain_start_cmd(self.did)
-
-    async def async_rain_stop_cmd(self) -> None:
-        if self.has_rain_stop_cmd:
-            await self.api.async_rain_stop_cmd(self.did)
-
-    async def async_goto_dawn_pos_cmd(self) -> None:
-        if self.has_goto_dawn_pos_cmd:
-            await self.api.async_goto_dawn_pos_cmd(self.did)
-
-    async def async_goto_dusk_pos_cmd(self) -> None:
-        if self.has_goto_dusk_pos_cmd:
-            await self.api.async_goto_dusk_pos_cmd(self.did)
+    # Weather program / contact commands are provided by HomePilotAutoConfigDevice.
 
     async def async_set_ventilation_position_mode(self, mode) -> None:
         if self.has_ventilation_position_config:
@@ -428,36 +357,3 @@ class HomePilotCover(HomePilotAutoConfigDevice):
     @rain_prog_active_value.setter
     def rain_prog_active_value(self, rain_prog_active_value):
         self._rain_prog_active_value = rain_prog_active_value
-
-    # New command capability properties
-    @property
-    def has_sun_start_cmd(self) -> bool:
-        return self._has_sun_start_cmd
-
-    @property
-    def has_sun_stop_cmd(self) -> bool:
-        return self._has_sun_stop_cmd
-
-    @property
-    def has_wind_start_cmd(self) -> bool:
-        return self._has_wind_start_cmd
-
-    @property
-    def has_wind_stop_cmd(self) -> bool:
-        return self._has_wind_stop_cmd
-
-    @property
-    def has_rain_start_cmd(self) -> bool:
-        return self._has_rain_start_cmd
-
-    @property
-    def has_rain_stop_cmd(self) -> bool:
-        return self._has_rain_stop_cmd
-
-    @property
-    def has_goto_dawn_pos_cmd(self) -> bool:
-        return self._has_goto_dawn_pos_cmd
-
-    @property
-    def has_goto_dusk_pos_cmd(self) -> bool:
-        return self._has_goto_dusk_pos_cmd

--- a/homepilot/device.py
+++ b/homepilot/device.py
@@ -22,6 +22,9 @@ from .const import (
     APICAP_GOTO_DUSK_POS_CMD,
     APICAP_CONTACT_OPEN_CMD,
     APICAP_CONTACT_CLOSE_CMD,
+    APICAP_SUN_PROG_ACTIVE_EVT,
+    APICAP_WIND_PROG_ACTIVE_EVT,
+    APICAP_RAIN_PROG_ACTIVE_EVT,
     APICAP_DEVICE_TYPE_LOC,
     APICAP_ID_DEVICE_LOC
 )
@@ -182,6 +185,12 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
     _has_goto_dusk_pos_cmd: bool
     _has_contact_open_cmd: bool
     _has_contact_close_cmd: bool
+    _has_sun_prog_active: bool
+    _sun_prog_active_value: bool
+    _has_wind_prog_active: bool
+    _wind_prog_active_value: bool
+    _has_rain_prog_active: bool
+    _rain_prog_active_value: bool
 
     def __init__(
         self,
@@ -229,6 +238,10 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         self._has_goto_dusk_pos_cmd = APICAP_GOTO_DUSK_POS_CMD in device_map
         self._has_contact_open_cmd = APICAP_CONTACT_OPEN_CMD in device_map
         self._has_contact_close_cmd = APICAP_CONTACT_CLOSE_CMD in device_map
+        # Weather program "active" events (read-only state)
+        self._has_sun_prog_active = APICAP_SUN_PROG_ACTIVE_EVT in device_map
+        self._has_wind_prog_active = APICAP_WIND_PROG_ACTIVE_EVT in device_map
+        self._has_rain_prog_active = APICAP_RAIN_PROG_ACTIVE_EVT in device_map
 
     async def update_device_state(self, state: Dict[str, Any], device_map: Optional[Dict[str, Any]]) -> None:
         if self.has_auto_mode:
@@ -252,6 +265,12 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
             self.rain_auto_mode_value = device_map.get(APICAP_RAIN_AUTO_CFG, {}).get("value", "false") == "true"
         if self.has_sun_auto_mode:
             self.sun_auto_mode_value = device_map.get(APICAP_SUN_AUTO_CFG, {}).get("value", "false") == "true"
+        if self.has_sun_prog_active:
+            self.sun_prog_active_value = device_map.get(APICAP_SUN_PROG_ACTIVE_EVT, {}).get("value", "false") == "true"
+        if self.has_wind_prog_active:
+            self.wind_prog_active_value = device_map.get(APICAP_WIND_PROG_ACTIVE_EVT, {}).get("value", "false") == "true"
+        if self.has_rain_prog_active:
+            self.rain_prog_active_value = device_map.get(APICAP_RAIN_PROG_ACTIVE_EVT, {}).get("value", "false") == "true"
 
     async def async_set_auto_mode(self, auto_mode) -> None:
         await self.api.async_set_auto_mode(self.did, auto_mode)
@@ -388,6 +407,42 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
     @property
     def has_contact_close_cmd(self) -> bool:
         return self._has_contact_close_cmd
+
+    @property
+    def has_sun_prog_active(self) -> bool:
+        return self._has_sun_prog_active
+
+    @property
+    def sun_prog_active_value(self) -> bool:
+        return self._sun_prog_active_value
+
+    @sun_prog_active_value.setter
+    def sun_prog_active_value(self, sun_prog_active_value):
+        self._sun_prog_active_value = sun_prog_active_value
+
+    @property
+    def has_wind_prog_active(self) -> bool:
+        return self._has_wind_prog_active
+
+    @property
+    def wind_prog_active_value(self) -> bool:
+        return self._wind_prog_active_value
+
+    @wind_prog_active_value.setter
+    def wind_prog_active_value(self, wind_prog_active_value):
+        self._wind_prog_active_value = wind_prog_active_value
+
+    @property
+    def has_rain_prog_active(self) -> bool:
+        return self._has_rain_prog_active
+
+    @property
+    def rain_prog_active_value(self) -> bool:
+        return self._rain_prog_active_value
+
+    @rain_prog_active_value.setter
+    def rain_prog_active_value(self, rain_prog_active_value):
+        self._rain_prog_active_value = rain_prog_active_value
 
     @property
     def auto_mode_value(self) -> bool:

--- a/homepilot/device.py
+++ b/homepilot/device.py
@@ -12,6 +12,16 @@ from .const import (
     APICAP_DUSK_AUTO_CFG,
     APICAP_RAIN_AUTO_CFG,
     APICAP_SUN_AUTO_CFG,
+    APICAP_SUN_START_CMD,
+    APICAP_SUN_STOP_CMD,
+    APICAP_WIND_START_CMD,
+    APICAP_WIND_STOP_CMD,
+    APICAP_RAIN_START_CMD,
+    APICAP_RAIN_STOP_CMD,
+    APICAP_GOTO_DAWN_POS_CMD,
+    APICAP_GOTO_DUSK_POS_CMD,
+    APICAP_CONTACT_OPEN_CMD,
+    APICAP_CONTACT_CLOSE_CMD,
     APICAP_DEVICE_TYPE_LOC,
     APICAP_ID_DEVICE_LOC
 )
@@ -162,6 +172,16 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
     _rain_auto_mode_value: bool
     _has_sun_auto_mode: bool
     _sun_auto_mode_value: bool
+    _has_sun_start_cmd: bool
+    _has_sun_stop_cmd: bool
+    _has_wind_start_cmd: bool
+    _has_wind_stop_cmd: bool
+    _has_rain_start_cmd: bool
+    _has_rain_stop_cmd: bool
+    _has_goto_dawn_pos_cmd: bool
+    _has_goto_dusk_pos_cmd: bool
+    _has_contact_open_cmd: bool
+    _has_contact_close_cmd: bool
 
     def __init__(
         self,
@@ -196,6 +216,19 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         self._has_dusk_auto_mode = APICAP_DUSK_AUTO_CFG in device_map
         self._has_rain_auto_mode = APICAP_RAIN_AUTO_CFG in device_map
         self._has_sun_auto_mode = APICAP_SUN_AUTO_CFG in device_map
+        # Weather/contact command capabilities. These are exposed by any
+        # auto config device (cover, switch/actuator, thermostat) that supports
+        # the corresponding command, not only covers/thermostats.
+        self._has_sun_start_cmd = APICAP_SUN_START_CMD in device_map
+        self._has_sun_stop_cmd = APICAP_SUN_STOP_CMD in device_map
+        self._has_wind_start_cmd = APICAP_WIND_START_CMD in device_map
+        self._has_wind_stop_cmd = APICAP_WIND_STOP_CMD in device_map
+        self._has_rain_start_cmd = APICAP_RAIN_START_CMD in device_map
+        self._has_rain_stop_cmd = APICAP_RAIN_STOP_CMD in device_map
+        self._has_goto_dawn_pos_cmd = APICAP_GOTO_DAWN_POS_CMD in device_map
+        self._has_goto_dusk_pos_cmd = APICAP_GOTO_DUSK_POS_CMD in device_map
+        self._has_contact_open_cmd = APICAP_CONTACT_OPEN_CMD in device_map
+        self._has_contact_close_cmd = APICAP_CONTACT_CLOSE_CMD in device_map
 
     async def update_device_state(self, state: Dict[str, Any], device_map: Optional[Dict[str, Any]]) -> None:
         if self.has_auto_mode:
@@ -244,6 +277,46 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
     async def async_set_sun_auto_mode(self, auto_mode) -> None:
         await self.api.async_set_sun_auto_mode(self.did, auto_mode)
 
+    async def async_sun_start_cmd(self) -> None:
+        if self.has_sun_start_cmd:
+            await self.api.async_sun_start_cmd(self.did)
+
+    async def async_sun_stop_cmd(self) -> None:
+        if self.has_sun_stop_cmd:
+            await self.api.async_sun_stop_cmd(self.did)
+
+    async def async_wind_start_cmd(self) -> None:
+        if self.has_wind_start_cmd:
+            await self.api.async_wind_start_cmd(self.did)
+
+    async def async_wind_stop_cmd(self) -> None:
+        if self.has_wind_stop_cmd:
+            await self.api.async_wind_stop_cmd(self.did)
+
+    async def async_rain_start_cmd(self) -> None:
+        if self.has_rain_start_cmd:
+            await self.api.async_rain_start_cmd(self.did)
+
+    async def async_rain_stop_cmd(self) -> None:
+        if self.has_rain_stop_cmd:
+            await self.api.async_rain_stop_cmd(self.did)
+
+    async def async_goto_dawn_pos_cmd(self) -> None:
+        if self.has_goto_dawn_pos_cmd:
+            await self.api.async_goto_dawn_pos_cmd(self.did)
+
+    async def async_goto_dusk_pos_cmd(self) -> None:
+        if self.has_goto_dusk_pos_cmd:
+            await self.api.async_goto_dusk_pos_cmd(self.did)
+
+    async def async_contact_open_cmd(self) -> None:
+        if self.has_contact_open_cmd:
+            await self.api.async_contact_open_cmd(self.did)
+
+    async def async_contact_close_cmd(self) -> None:
+        if self.has_contact_close_cmd:
+            await self.api.async_contact_close_cmd(self.did)
+
     @property
     def has_auto_mode(self) -> bool:
         return self._has_auto_mode
@@ -275,6 +348,46 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
     @property
     def has_sun_auto_mode(self) -> bool:
         return self._has_sun_auto_mode
+
+    @property
+    def has_sun_start_cmd(self) -> bool:
+        return self._has_sun_start_cmd
+
+    @property
+    def has_sun_stop_cmd(self) -> bool:
+        return self._has_sun_stop_cmd
+
+    @property
+    def has_wind_start_cmd(self) -> bool:
+        return self._has_wind_start_cmd
+
+    @property
+    def has_wind_stop_cmd(self) -> bool:
+        return self._has_wind_stop_cmd
+
+    @property
+    def has_rain_start_cmd(self) -> bool:
+        return self._has_rain_start_cmd
+
+    @property
+    def has_rain_stop_cmd(self) -> bool:
+        return self._has_rain_stop_cmd
+
+    @property
+    def has_goto_dawn_pos_cmd(self) -> bool:
+        return self._has_goto_dawn_pos_cmd
+
+    @property
+    def has_goto_dusk_pos_cmd(self) -> bool:
+        return self._has_goto_dusk_pos_cmd
+
+    @property
+    def has_contact_open_cmd(self) -> bool:
+        return self._has_contact_open_cmd
+
+    @property
+    def has_contact_close_cmd(self) -> bool:
+        return self._has_contact_close_cmd
 
     @property
     def auto_mode_value(self) -> bool:

--- a/homepilot/thermostat.py
+++ b/homepilot/thermostat.py
@@ -16,14 +16,6 @@ from .const import (
     APICAP_INT_OPEN_WINDOW_DETECT_EVT,
     APICAP_BOOST_TIME_CFG,
     APICAP_BOOST_ACTIVE_CFG,
-    APICAP_CONTACT_OPEN_CMD,
-    APICAP_CONTACT_CLOSE_CMD,
-    APICAP_EXT_OPEN_WINDOW_DETECT_EVT,
-    APICAP_INT_OPEN_WINDOW_DETECT_EVT,
-    APICAP_BOOST_TIME_CFG,
-    APICAP_BOOST_ACTIVE_CFG,
-    APICAP_CONTACT_OPEN_CMD,
-    APICAP_CONTACT_CLOSE_CMD,
     SUPPORTED_DEVICES,
 )
 from .api import HomePilotApi
@@ -58,8 +50,6 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
     _boost_time_value: float
     _has_boost_active: bool
     _boost_active_value: bool
-    _has_contact_open_cmd: bool
-    _has_contact_close_cmd: bool
 
     def __init__(
         self,
@@ -86,8 +76,6 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         has_int_open_window_detect: bool = False,
         has_boost_time: bool = False,
         has_boost_active: bool = False,
-        has_contact_open_cmd: bool = False,
-        has_contact_close_cmd: bool = False,
         device_map: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(
@@ -117,9 +105,6 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         self._has_int_open_window_detect = has_int_open_window_detect
         self._has_boost_time = has_boost_time
         self._has_boost_active = has_boost_active
-        # Initialize new contact command properties
-        self._has_contact_open_cmd = has_contact_open_cmd
-        self._has_contact_close_cmd = has_contact_close_cmd
         self._has_temperature_thresh_cfg = [None] * 4
         self._temperature_thresh_cfg_value = [None] * 4
         self._temperature_thresh_cfg_min = [None] * 4
@@ -188,8 +173,6 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
             has_int_open_window_detect=APICAP_INT_OPEN_WINDOW_DETECT_EVT in device_map,
             has_boost_time=APICAP_BOOST_TIME_CFG in device_map,
             has_boost_active=APICAP_BOOST_ACTIVE_CFG in device_map,
-            has_contact_open_cmd=APICAP_CONTACT_OPEN_CMD in device_map,
-            has_contact_close_cmd=APICAP_CONTACT_CLOSE_CMD in device_map,
             device_map=device_map,
         )
 
@@ -234,14 +217,6 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
 
     async def async_set_temperature_thresh_cfg(self, thresh_number, temperature) -> None:
         await self.api.async_set_temperature_thresh_cfg(self.did, thresh_number, temperature)
-
-    async def async_contact_open_cmd(self) -> None:
-        if self.has_contact_open_cmd:
-            await self.api.async_contact_open_cmd(self.did)
-
-    async def async_contact_close_cmd(self) -> None:
-        if self.has_contact_close_cmd:
-            await self.api.async_contact_close_cmd(self.did)
 
     async def async_set_boost_active_cfg(self, boost_active) -> None:
         await self.api.async_set_boost_active_cfg(self.did, boost_active)
@@ -389,11 +364,3 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
     @boost_active_value.setter
     def boost_active_value(self, boost_active_value):
         self._boost_active_value = boost_active_value
-
-    @property
-    def has_contact_open_cmd(self) -> bool:
-        return self._has_contact_open_cmd
-
-    @property
-    def has_contact_close_cmd(self) -> bool:
-        return self._has_contact_close_cmd

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyrademacher",
-    version="0.15.0",
+    version="0.16.0",
     author="Pedro Ribeiro",
     author_email="pedroeusebio@gmail.com",
     description="Control devices connected to your Rademacher Homepilot "

--- a/tests/test_auto_config_device.py
+++ b/tests/test_auto_config_device.py
@@ -42,6 +42,16 @@ from homepilot.const import (
     APICAP_DUSK_AUTO_CFG,
     APICAP_RAIN_AUTO_CFG,
     APICAP_SUN_AUTO_CFG,
+    APICAP_SUN_START_CMD,
+    APICAP_SUN_STOP_CMD,
+    APICAP_WIND_START_CMD,
+    APICAP_WIND_STOP_CMD,
+    APICAP_RAIN_START_CMD,
+    APICAP_RAIN_STOP_CMD,
+    APICAP_GOTO_DAWN_POS_CMD,
+    APICAP_GOTO_DUSK_POS_CMD,
+    APICAP_CONTACT_OPEN_CMD,
+    APICAP_CONTACT_CLOSE_CMD,
 )
 
 
@@ -823,3 +833,125 @@ class TestAutoConfigChildClasses:
 
         # Cover-specific functionality should still work
         assert cover.can_set_position is True
+
+
+# (capability constant, has_*_cmd property, async_*_cmd method, api method)
+COMMAND_MATRIX = [
+    (APICAP_SUN_START_CMD, "has_sun_start_cmd", "async_sun_start_cmd"),
+    (APICAP_SUN_STOP_CMD, "has_sun_stop_cmd", "async_sun_stop_cmd"),
+    (APICAP_WIND_START_CMD, "has_wind_start_cmd", "async_wind_start_cmd"),
+    (APICAP_WIND_STOP_CMD, "has_wind_stop_cmd", "async_wind_stop_cmd"),
+    (APICAP_RAIN_START_CMD, "has_rain_start_cmd", "async_rain_start_cmd"),
+    (APICAP_RAIN_STOP_CMD, "has_rain_stop_cmd", "async_rain_stop_cmd"),
+    (APICAP_GOTO_DAWN_POS_CMD, "has_goto_dawn_pos_cmd", "async_goto_dawn_pos_cmd"),
+    (APICAP_GOTO_DUSK_POS_CMD, "has_goto_dusk_pos_cmd", "async_goto_dusk_pos_cmd"),
+    (APICAP_CONTACT_OPEN_CMD, "has_contact_open_cmd", "async_contact_open_cmd"),
+    (APICAP_CONTACT_CLOSE_CMD, "has_contact_close_cmd", "async_contact_close_cmd"),
+]
+
+
+class TestAutoConfigDeviceCommands:
+    """Test the weather/contact command capabilities (sun/wind/rain start-stop,
+    goto dawn/dusk position, contact open/close) that are provided by
+    HomePilotAutoConfigDevice and therefore available to every device type that
+    inherits from it (cover, switch/actuator, thermostat, light)."""
+
+    @pytest.fixture
+    def mocked_api(self):
+        api = MagicMock(spec=HomePilotApi)
+        for _, _, method in COMMAND_MATRIX:
+            future = asyncio.Future()
+            future.set_result(None)
+            getattr(api, method).return_value = future
+        return api
+
+    @pytest.fixture
+    def device_data(self):
+        return {
+            "did": 123,
+            "uid": "test-uid-123",
+            "name": "Test Auto Device",
+            "device_number": "DEV001",
+            "model": "TestModel",
+            "fw_version": "1.0.0",
+            "device_group": 1,
+            "has_ping_cmd": True,
+        }
+
+    @pytest.fixture
+    def full_command_map(self):
+        """Device map advertising every weather/contact command capability."""
+        return {cap: {"value": None} for cap, _, _ in COMMAND_MATRIX}
+
+    def test_command_capabilities_detected(self, mocked_api, device_data, full_command_map):
+        """All has_*_cmd properties are True when the capability is present."""
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api, device_map=full_command_map, **device_data
+        )
+        for _, has_attr, _ in COMMAND_MATRIX:
+            assert getattr(device, has_attr) is True, has_attr
+
+    def test_command_capabilities_absent_empty_map(self, mocked_api, device_data):
+        """All has_*_cmd properties are False for an empty device map."""
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api, device_map={}, **device_data
+        )
+        for _, has_attr, _ in COMMAND_MATRIX:
+            assert getattr(device, has_attr) is False, has_attr
+
+    def test_command_capabilities_absent_no_map(self, mocked_api, device_data):
+        """All has_*_cmd properties are False when device_map is None."""
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api, device_map=None, **device_data
+        )
+        for _, has_attr, _ in COMMAND_MATRIX:
+            assert getattr(device, has_attr) is False, has_attr
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cap,has_attr,method", COMMAND_MATRIX)
+    async def test_async_command_calls_api_with_did(
+        self, mocked_api, device_data, cap, has_attr, method
+    ):
+        """When the capability is present, the command forwards to the API
+        using the device id."""
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api, device_map={cap: {"value": None}}, **device_data
+        )
+        assert getattr(device, has_attr) is True
+        await getattr(device, method)()
+        getattr(mocked_api, method).assert_called_once_with(123)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cap,has_attr,method", COMMAND_MATRIX)
+    async def test_async_command_noop_when_capability_absent(
+        self, mocked_api, device_data, cap, has_attr, method
+    ):
+        """Without the capability the command is a no-op and never hits the API."""
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api, device_map={}, **device_data
+        )
+        assert getattr(device, has_attr) is False
+        await getattr(device, method)()
+        getattr(mocked_api, method).assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_switch_exposes_and_forwards_commands(self, mocked_api, full_command_map):
+        """A switch/actuator (which only inherits from HomePilotAutoConfigDevice)
+        now exposes the command capabilities and forwards them to the API."""
+        switch = HomePilotSwitch(
+            api=mocked_api,
+            did=789,
+            uid="switch-uid",
+            name="Test Switch",
+            device_number="SWI001",
+            model="TestSwitchModel",
+            fw_version="1.0.0",
+            device_group=3,
+            has_ping_cmd=True,
+            device_map=full_command_map,
+        )
+        assert isinstance(switch, HomePilotAutoConfigDevice)
+        for _, has_attr, method in COMMAND_MATRIX:
+            assert getattr(switch, has_attr) is True, has_attr
+            await getattr(switch, method)()
+            getattr(mocked_api, method).assert_called_with(789)

--- a/tests/test_auto_config_device.py
+++ b/tests/test_auto_config_device.py
@@ -52,6 +52,9 @@ from homepilot.const import (
     APICAP_GOTO_DUSK_POS_CMD,
     APICAP_CONTACT_OPEN_CMD,
     APICAP_CONTACT_CLOSE_CMD,
+    APICAP_SUN_PROG_ACTIVE_EVT,
+    APICAP_WIND_PROG_ACTIVE_EVT,
+    APICAP_RAIN_PROG_ACTIVE_EVT,
 )
 
 
@@ -955,3 +958,79 @@ class TestAutoConfigDeviceCommands:
             assert getattr(switch, has_attr) is True, has_attr
             await getattr(switch, method)()
             getattr(mocked_api, method).assert_called_with(789)
+
+
+# (capability constant, has_*_prog_active property, *_prog_active_value property)
+PROG_ACTIVE_MATRIX = [
+    (APICAP_SUN_PROG_ACTIVE_EVT, "has_sun_prog_active", "sun_prog_active_value"),
+    (APICAP_WIND_PROG_ACTIVE_EVT, "has_wind_prog_active", "wind_prog_active_value"),
+    (APICAP_RAIN_PROG_ACTIVE_EVT, "has_rain_prog_active", "rain_prog_active_value"),
+]
+
+
+class TestAutoConfigDeviceProgActive:
+    """Test the weather program "active" events (sun/wind/rain) that are
+    provided by HomePilotAutoConfigDevice and therefore available to every
+    device type that inherits from it (cover, switch/actuator, ...)."""
+
+    @pytest.fixture
+    def mocked_api(self):
+        return MagicMock(spec=HomePilotApi)
+
+    @pytest.fixture
+    def device_data(self):
+        return {
+            "did": 123,
+            "uid": "test-uid-123",
+            "name": "Test Auto Device",
+            "device_number": "DEV001",
+            "model": "TestModel",
+            "fw_version": "1.0.0",
+            "device_group": 1,
+            "has_ping_cmd": True,
+        }
+
+    def test_prog_active_detected(self, mocked_api, device_data):
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api,
+            device_map={cap: {"value": "false"} for cap, _, _ in PROG_ACTIVE_MATRIX},
+            **device_data,
+        )
+        for _, has_attr, _ in PROG_ACTIVE_MATRIX:
+            assert getattr(device, has_attr) is True, has_attr
+
+    def test_prog_active_absent(self, mocked_api, device_data):
+        device = HomePilotAutoConfigDevice(api=mocked_api, device_map={}, **device_data)
+        for _, has_attr, _ in PROG_ACTIVE_MATRIX:
+            assert getattr(device, has_attr) is False, has_attr
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cap,has_attr,value_attr", PROG_ACTIVE_MATRIX)
+    async def test_prog_active_value_updates_from_state(
+        self, mocked_api, device_data, cap, has_attr, value_attr
+    ):
+        device = HomePilotAutoConfigDevice(
+            api=mocked_api, device_map={cap: {"value": "false"}}, **device_data
+        )
+        state = {"statusesMap": {}}
+        await device.update_device_state(state, {cap: {"value": "true"}})
+        assert getattr(device, value_attr) is True
+        await device.update_device_state(state, {cap: {"value": "false"}})
+        assert getattr(device, value_attr) is False
+
+    def test_switch_inherits_prog_active(self, mocked_api):
+        switch = HomePilotSwitch(
+            api=mocked_api,
+            did=789,
+            uid="switch-uid",
+            name="Test Switch",
+            device_number="SWI001",
+            model="TestSwitchModel",
+            fw_version="1.0.0",
+            device_group=3,
+            has_ping_cmd=True,
+            device_map={cap: {"value": "false"} for cap, _, _ in PROG_ACTIVE_MATRIX},
+        )
+        assert isinstance(switch, HomePilotAutoConfigDevice)
+        for _, has_attr, _ in PROG_ACTIVE_MATRIX:
+            assert getattr(switch, has_attr) is True, has_attr


### PR DESCRIPTION
# Expose command and program-active capabilities on all auto config devices

_Repo:_ pyrademacher · _Branch:_ `feat/auto-config-device-commands` · _Base:_ `master`

## Summary

The weather/contact **commands** (sun/wind/rain start–stop, goto dawn/dusk position, contact open/close) lived only on `HomePilotCover` / `HomePilotThermostat`, and the sun/wind/rain **program-active events** only on `HomePilotCover` — even though other device types (switches/actuators, dimmers) advertise the same capabilities.

This PR moves both into the shared `HomePilotAutoConfigDevice` base class, so every inheriting device type (cover, switch/actuator, thermostat, light) that reports the capability exposes it. Switch/actuator devices (`DEVICE_TYPE` 1) previously exposed none of these.

## Changes

- **`device.py`** – parse the `*_CMD` and `*_PROG_ACTIVE_EVT` capabilities on the base class; add `has_*_cmd` / `async_*_cmd` methods and `has_*_prog_active` / `*_prog_active_value` properties; update program-active values in `update_device_state`.
- **`cover.py` / `thermostat.py`** – drop the now-duplicated declarations (single source of truth).
- **`tests`** – add `TestAutoConfigDeviceCommands` (capability detection, API wiring with the device id, no-op when absent, switch inheritance) and `TestAutoConfigDeviceProgActive` (detection, value updates from state, switch inheritance).
- **`README.md`** – document the command and program-active capabilities.
- **version** – bump to `0.16.0`.

## Testing

Full test suite green — **142 passed** — including the new base-class tests; flake8 (`E9,F63,F7,F82`) clean.
