### PR TITLE
fix: API-layer scene id normalization + drop null command value; cons…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ api = HomePilotApi("hostname", "password") # password can be empty if not define
 
 print(asyncio.run(asyncio.run(api.get_devices()))) # get all devices
 
-asyncio.run(api.async_open_cover(did=1)) # open cover for device id 1 (assuming it's a cover device)
+asyncio.run(api.async_open_cover(did="1")) # open cover for device id "1" (assuming it's a cover device)
 ```
 
 ### Manager Class
@@ -99,7 +99,7 @@ manager = asyncio.run(HomePilotManager.async_build_manager(api))
 manager = asyncio.run(HomePilotManager.async_build_manager(api, include_non_manual_executable=True))
 
 # Access scene properties
-scene = manager.scenes[1]  # Scene with ID 1
+scene = manager.scenes["1"]  # Scene with ID "1"
 print(f"Scene: {scene.name}")
 print(f"Description: {scene.description}")
 print(f"Enabled: {scene.is_enabled}")

--- a/homepilot/actuator.py
+++ b/homepilot/actuator.py
@@ -21,7 +21,7 @@ class HomePilotActuator(HomePilotAutoConfigDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -71,7 +71,7 @@ class HomePilotActuator(HomePilotAutoConfigDevice):
             device_map=device_map,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         self.is_on = state["statusesMap"]["Position"] != 0
         self.brightness = state["statusesMap"]["Position"]
@@ -83,7 +83,7 @@ class HomePilotActuator(HomePilotAutoConfigDevice):
         return self._is_on
 
     @is_on.setter
-    def is_on(self, is_on):
+    def is_on(self, is_on: bool) -> None:
         self._is_on = is_on
 
     @property
@@ -91,7 +91,7 @@ class HomePilotActuator(HomePilotAutoConfigDevice):
         return self._brightness
 
     @brightness.setter
-    def brightness(self, brightness):
+    def brightness(self, brightness: int) -> None:
         self._brightness = brightness
 
     async def async_turn_on(self) -> None:
@@ -100,7 +100,7 @@ class HomePilotActuator(HomePilotAutoConfigDevice):
     async def async_turn_off(self) -> None:
         await self.api.async_turn_off(self.did)
 
-    async def async_set_brightness(self, new_brightness) -> None:
+    async def async_set_brightness(self, new_brightness: int) -> None:
         await self.api.async_set_position(self.did, new_brightness)
 
     async def async_toggle(self) -> None:

--- a/homepilot/api.py
+++ b/homepilot/api.py
@@ -161,7 +161,7 @@ class HomePilotApi:
                 return devices
             return []
 
-    async def get_device(self, did):
+    async def get_device(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.get(f"http://{self._host}{self._base_path}/devices/{did}") as response:
@@ -228,7 +228,7 @@ class HomePilotApi:
             response = await response.json()
             return response
 
-    async def async_get_device_state(self, did):
+    async def async_get_device_state(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.get(
@@ -291,7 +291,7 @@ class HomePilotApi:
                     transmitters = {}
         return {**actuators, **sensors, **transmitters}
 
-    async def async_ping(self, did):
+    async def async_ping(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -299,7 +299,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_open_cover(self, did):
+    async def async_open_cover(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -307,7 +307,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_close_cover(self, did):
+    async def async_close_cover(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -315,7 +315,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_stop_cover(self, did):
+    async def async_stop_cover(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -323,7 +323,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_position(self, did, position):
+    async def async_set_position(self, did: str, position: int):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -332,7 +332,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_open_cover_tilt(self, did) -> None:
+    async def async_open_cover_tilt(self, did: str) -> None:
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -341,7 +341,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_close_cover_tilt(self, did) -> None:
+    async def async_close_cover_tilt(self, did: str) -> None:
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -350,7 +350,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_cover_tilt_position(self, did, position) -> None:
+    async def async_set_cover_tilt_position(self, did: str, position: int) -> None:
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -359,7 +359,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_stop_cover_tilt(self, did) -> None:
+    async def async_stop_cover_tilt(self, did: str) -> None:
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -368,7 +368,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_ventilation_position_mode(self, did, mode) -> None:
+    async def async_set_ventilation_position_mode(self, did: str, mode: bool) -> None:
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -377,7 +377,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_ventilation_position(self, did, position) -> None:
+    async def async_set_ventilation_position(self, did: str, position: int) -> None:
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -386,7 +386,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_turn_on(self, did):
+    async def async_turn_on(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -394,7 +394,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_turn_off(self, did):
+    async def async_turn_off(self, did: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -402,7 +402,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_target_temperature(self, did, temperature):
+    async def async_set_target_temperature(self, did: str, temperature: float):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -411,19 +411,22 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_send_device_command(self, did, command, value):
+    async def async_send_device_command(self, did: str, command: str, value: Any = None):
         await self.authenticate()
         session = await self._get_session()
+        body = {"name": command}
+        if value is not None:
+            body["value"] = value
         async with session.put(
             f"http://{self._host}{self._base_path}/devices/{did}",
-            json={"name": command, "value": value},
+            json=body,
         ) as response:
             return await response.json()
 
-    async def async_set_auto_mode(self, did, auto_mode):
+    async def async_set_auto_mode(self, did: str, auto_mode: bool):
         return await self.async_send_device_command(did, APICAP_AUTO_MODE_CFG, auto_mode)
 
-    async def async_set_temperature_thresh_cfg(self, did, thresh_number, temperature):
+    async def async_set_temperature_thresh_cfg(self, did: str, thresh_number: int, temperature: float):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -432,7 +435,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_rgb(self, did, rgb_value):
+    async def async_set_rgb(self, did: str, rgb_value: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -441,7 +444,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_color_temp(self, did, color_temp_value):
+    async def async_set_color_temp(self, did: str, color_temp_value: int):
         await self.authenticate()
         session = await self._get_session()
         async with session.put(
@@ -493,6 +496,20 @@ class HomePilotApi:
             return await response.json()
 
 # Scenes
+    @staticmethod
+    def _normalize_scene_ids(scenes):
+        """Normalize scene ids to str.
+
+        The bridge /scenes endpoint returns the scene id as a raw JSON number,
+        whereas device ids (capability values) are always strings. Converting
+        here keeps ids consistently str everywhere downstream (manager keys,
+        scene.sid), so callers never have to second-guess the id type.
+        """
+        for scene in scenes:
+            if "id" in scene:
+                scene["id"] = str(scene["id"])
+        return scenes
+
     async def async_get_scenes(self):
         await self.authenticate()
         session = await self._get_session()
@@ -504,8 +521,7 @@ class HomePilotApi:
             if response.status == 200:
                 responseJson = await response.json()
                 if "scenes" in responseJson:
-                    scenes = responseJson["scenes"]
-                    return scenes
+                    return self._normalize_scene_ids(responseJson["scenes"])
             return []
 
     async def async_get_scenes_v4(self):
@@ -519,11 +535,10 @@ class HomePilotApi:
             if response.status == 200:
                 responseJson = await response.json()
                 if "scenes" in responseJson:
-                    scenes = responseJson["scenes"]
-                    return scenes
+                    return self._normalize_scene_ids(responseJson["scenes"])
             return []
 
-    async def async_execute_scene(self, sid: int):
+    async def async_execute_scene(self, sid: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.post(
@@ -532,7 +547,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_activate_scene(self, sid: int):
+    async def async_activate_scene(self, sid: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.post(
@@ -541,7 +556,7 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_deactivate_scene(self, sid: int):
+    async def async_deactivate_scene(self, sid: str):
         await self.authenticate()
         session = await self._get_session()
         async with session.post(
@@ -550,61 +565,61 @@ class HomePilotApi:
         ) as response:
             return await response.json()
 
-    async def async_set_time_auto_mode(self, did, auto_mode):
+    async def async_set_time_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_TIME_AUTO_CFG, auto_mode)
 
-    async def async_set_contact_auto_mode(self, did, auto_mode):
+    async def async_set_contact_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_CONTACT_AUTO_CFG, auto_mode)
 
-    async def async_set_wind_auto_mode(self, did, auto_mode):
+    async def async_set_wind_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_WIND_AUTO_CFG, auto_mode)
 
-    async def async_set_dawn_auto_mode(self, did, auto_mode):
+    async def async_set_dawn_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_DAWN_AUTO_CFG, auto_mode)
 
-    async def async_set_dusk_auto_mode(self, did, auto_mode):
+    async def async_set_dusk_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_DUSK_AUTO_CFG, auto_mode)
 
-    async def async_set_rain_auto_mode(self, did, auto_mode):
+    async def async_set_rain_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_RAIN_AUTO_CFG, auto_mode)
 
-    async def async_set_sun_auto_mode(self, did, auto_mode):
+    async def async_set_sun_auto_mode(self, did: str, auto_mode: bool):
         await self.async_send_device_command(did, APICAP_SUN_AUTO_CFG, auto_mode)
 
-    async def async_contact_open_cmd(self, did):
+    async def async_contact_open_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_CONTACT_OPEN_CMD, None)
 
-    async def async_contact_close_cmd(self, did):
+    async def async_contact_close_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_CONTACT_CLOSE_CMD, None)
 
-    async def async_set_boost_active_cfg(self, did, boost_active):
+    async def async_set_boost_active_cfg(self, did: str, boost_active: bool):
         return await self.async_send_device_command(did, APICAP_BOOST_ACTIVE_CFG, boost_active)
 
-    async def async_set_boost_time_cfg(self, did, boost_time):
+    async def async_set_boost_time_cfg(self, did: str, boost_time: float):
         return await self.async_send_device_command(did, APICAP_BOOST_TIME_CFG, boost_time)
 
-    async def async_sun_start_cmd(self, did):
+    async def async_sun_start_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_SUN_START_CMD, None)
 
-    async def async_sun_stop_cmd(self, did):
+    async def async_sun_stop_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_SUN_STOP_CMD, None)
 
-    async def async_wind_start_cmd(self, did):
+    async def async_wind_start_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_WIND_START_CMD, None)
 
-    async def async_wind_stop_cmd(self, did):
+    async def async_wind_stop_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_WIND_STOP_CMD, None)
 
-    async def async_rain_start_cmd(self, did):
+    async def async_rain_start_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_RAIN_START_CMD, None)
 
-    async def async_rain_stop_cmd(self, did):
+    async def async_rain_stop_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_RAIN_STOP_CMD, None)
 
-    async def async_goto_dawn_pos_cmd(self, did):
+    async def async_goto_dawn_pos_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_GOTO_DAWN_POS_CMD, None)
 
-    async def async_goto_dusk_pos_cmd(self, did):
+    async def async_goto_dusk_pos_cmd(self, did: str):
         return await self.async_send_device_command(did, APICAP_GOTO_DUSK_POS_CMD, None)
 
     @property

--- a/homepilot/cover.py
+++ b/homepilot/cover.py
@@ -48,7 +48,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -119,7 +119,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
             device_map=device_map,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         self.cover_position = 100 - state["statusesMap"]["Position"]
         if self.has_tilt:
@@ -149,7 +149,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
     async def async_close_cover(self) -> None:
         await self.api.async_close_cover(self.did)
 
-    async def async_set_cover_position(self, new_position) -> None:
+    async def async_set_cover_position(self, new_position: int) -> None:
         if self.can_set_position:
             await self.api.async_set_position(self.did,
                                               100 - new_position)
@@ -165,7 +165,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         if self.has_tilt:
             await self.api.async_close_cover_tilt(self.did)
 
-    async def async_set_cover_tilt_position(self, new_position) -> None:
+    async def async_set_cover_tilt_position(self, new_position: int) -> None:
         if self.has_tilt and self.can_set_tilt_position:
             await self.api.async_set_cover_tilt_position(self.did,
                                                          100 - new_position)
@@ -176,11 +176,11 @@ class HomePilotCover(HomePilotAutoConfigDevice):
 
     # Weather program / contact commands are provided by HomePilotAutoConfigDevice.
 
-    async def async_set_ventilation_position_mode(self, mode) -> None:
+    async def async_set_ventilation_position_mode(self, mode: bool) -> None:
         if self.has_ventilation_position_config:
             await self.api.async_set_ventilation_position_mode(self.did, mode)
 
-    async def async_set_ventilation_position(self, position) -> None:
+    async def async_set_ventilation_position(self, position: int) -> None:
         if self.has_ventilation_position_config:
             await self.api.async_set_ventilation_position(self.did, 100 - position)
 
@@ -193,11 +193,11 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._cover_tilt_position
 
     @cover_tilt_position.setter
-    def cover_tilt_position(self, cover_tilt_position):
+    def cover_tilt_position(self, cover_tilt_position: int) -> None:
         self._cover_tilt_position = cover_tilt_position
 
     @cover_position.setter
-    def cover_position(self, cover_position):
+    def cover_position(self, cover_position: int) -> None:
         self._cover_position = cover_position
 
     @property
@@ -205,7 +205,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._is_closed
 
     @is_closed.setter
-    def is_closed(self, is_closed):
+    def is_closed(self, is_closed: bool) -> None:
         self._is_closed = is_closed
 
     @property
@@ -213,7 +213,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._is_closing
 
     @is_closing.setter
-    def is_closing(self, is_closing):
+    def is_closing(self, is_closing: bool) -> None:
         self._is_closing = is_closing
 
     @property
@@ -221,7 +221,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._is_opening
 
     @is_opening.setter
-    def is_opening(self, is_opening):
+    def is_opening(self, is_opening: bool) -> None:
         self._is_opening = is_opening
 
     @property
@@ -237,7 +237,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._has_tilt
 
     @has_tilt.setter
-    def has_tilt(self, has_tilt):
+    def has_tilt(self, has_tilt: bool) -> None:
         self._has_tilt = has_tilt
 
     @property
@@ -245,7 +245,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._can_set_tilt_position
 
     @can_set_tilt_position.setter
-    def can_set_tilt_position(self, can_set_tilt_position):
+    def can_set_tilt_position(self, can_set_tilt_position: bool) -> None:
         self._can_set_tilt_position = can_set_tilt_position
 
     @property
@@ -253,7 +253,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._has_ventilation_position_config
 
     @has_ventilation_position_config.setter
-    def has_ventilation_position_config(self, has_ventilation_position_config):
+    def has_ventilation_position_config(self, has_ventilation_position_config: bool) -> None:
         self._has_ventilation_position_config = has_ventilation_position_config
 
     @property
@@ -261,7 +261,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._ventilation_position_mode
 
     @ventilation_position_mode.setter
-    def ventilation_position_mode(self, ventilation_position_mode):
+    def ventilation_position_mode(self, ventilation_position_mode: bool) -> None:
         self._ventilation_position_mode = ventilation_position_mode
 
     @property
@@ -269,7 +269,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._ventilation_position
 
     @ventilation_position.setter
-    def ventilation_position(self, ventilation_position):
+    def ventilation_position(self, ventilation_position: int) -> None:
         self._ventilation_position = ventilation_position
 
     @property
@@ -281,7 +281,7 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._blocking_detection_status
 
     @blocking_detection_status.setter
-    def blocking_detection_status(self, blocking_detection_status):
+    def blocking_detection_status(self, blocking_detection_status: bool) -> None:
         self._blocking_detection_status = blocking_detection_status
 
     @property
@@ -293,5 +293,5 @@ class HomePilotCover(HomePilotAutoConfigDevice):
         return self._obstacle_detection_status
 
     @obstacle_detection_status.setter
-    def obstacle_detection_status(self, obstacle_detection_status):
+    def obstacle_detection_status(self, obstacle_detection_status: bool) -> None:
         self._obstacle_detection_status = obstacle_detection_status

--- a/homepilot/device.py
+++ b/homepilot/device.py
@@ -34,7 +34,7 @@ class HomePilotDevice:
     """HomePilot Device"""
 
     _api: HomePilotApi
-    _did: int
+    _did: str
     _uid: str
     _name: str
     _device_number: str
@@ -48,7 +48,7 @@ class HomePilotDevice:
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -100,7 +100,7 @@ class HomePilotDevice:
             "type": device_map[APICAP_DEVICE_TYPE_LOC]["value"],
         }
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         self.available = state["statusValid"]
 
     async def async_ping(self):
@@ -112,39 +112,39 @@ class HomePilotDevice:
         return self._api
 
     @property
-    def did(self):
+    def did(self) -> str:
         return self._did
 
     @property
-    def uid(self):
+    def uid(self) -> str:
         return self._uid
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def device_number(self):
+    def device_number(self) -> str:
         return self._device_number
 
     @property
-    def model(self):
+    def model(self) -> str:
         return self._model
 
     @property
-    def fw_version(self):
+    def fw_version(self) -> str:
         return self._fw_version
 
     @property
-    def device_group(self):
+    def device_group(self) -> int:
         return self._device_group
 
     @property
-    def manufacturer(self):
+    def manufacturer(self) -> str:
         return self._manufacturer
 
     @property
-    def has_ping_cmd(self):
+    def has_ping_cmd(self) -> bool:
         return self._has_ping_cmd
 
     @property
@@ -152,11 +152,11 @@ class HomePilotDevice:
         return self._available
 
     @available.setter
-    def available(self, available):
+    def available(self, available: bool) -> None:
         self._available = available
 
     @property
-    def extra_attributes(self):
+    def extra_attributes(self) -> Optional[Dict[str, Any]]:
         return None
 
 
@@ -197,7 +197,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -274,28 +274,28 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         if self.has_rain_prog_active:
             self.rain_prog_active_value = device_map.get(APICAP_RAIN_PROG_ACTIVE_EVT, {}).get("value", "false") == "true"
 
-    async def async_set_auto_mode(self, auto_mode) -> None:
+    async def async_set_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_auto_mode(self.did, auto_mode)
 
-    async def async_set_time_auto_mode(self, auto_mode) -> None:
+    async def async_set_time_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_time_auto_mode(self.did, auto_mode)
 
-    async def async_set_contact_auto_mode(self, auto_mode) -> None:
+    async def async_set_contact_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_contact_auto_mode(self.did, auto_mode)
 
-    async def async_set_wind_auto_mode(self, auto_mode) -> None:
+    async def async_set_wind_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_wind_auto_mode(self.did, auto_mode)
 
-    async def async_set_dawn_auto_mode(self, auto_mode) -> None:
+    async def async_set_dawn_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_dawn_auto_mode(self.did, auto_mode)
 
-    async def async_set_dusk_auto_mode(self, auto_mode) -> None:
+    async def async_set_dusk_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_dusk_auto_mode(self.did, auto_mode)
 
-    async def async_set_rain_auto_mode(self, auto_mode) -> None:
+    async def async_set_rain_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_rain_auto_mode(self.did, auto_mode)
 
-    async def async_set_sun_auto_mode(self, auto_mode) -> None:
+    async def async_set_sun_auto_mode(self, auto_mode: bool) -> None:
         await self.api.async_set_sun_auto_mode(self.did, auto_mode)
 
     async def async_sun_start_cmd(self) -> None:
@@ -419,7 +419,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._sun_prog_active_value
 
     @sun_prog_active_value.setter
-    def sun_prog_active_value(self, sun_prog_active_value):
+    def sun_prog_active_value(self, sun_prog_active_value: bool) -> None:
         self._sun_prog_active_value = sun_prog_active_value
 
     @property
@@ -431,7 +431,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._wind_prog_active_value
 
     @wind_prog_active_value.setter
-    def wind_prog_active_value(self, wind_prog_active_value):
+    def wind_prog_active_value(self, wind_prog_active_value: bool) -> None:
         self._wind_prog_active_value = wind_prog_active_value
 
     @property
@@ -443,7 +443,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._rain_prog_active_value
 
     @rain_prog_active_value.setter
-    def rain_prog_active_value(self, rain_prog_active_value):
+    def rain_prog_active_value(self, rain_prog_active_value: bool) -> None:
         self._rain_prog_active_value = rain_prog_active_value
 
     @property
@@ -451,7 +451,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._auto_mode_value
 
     @auto_mode_value.setter
-    def auto_mode_value(self, auto_mode_value):
+    def auto_mode_value(self, auto_mode_value: bool) -> None:
         self._auto_mode_value = auto_mode_value
 
     @property
@@ -459,7 +459,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._time_auto_mode_value
 
     @time_auto_mode_value.setter
-    def time_auto_mode_value(self, time_auto_mode_value):
+    def time_auto_mode_value(self, time_auto_mode_value: bool) -> None:
         self._time_auto_mode_value = time_auto_mode_value
 
     @property
@@ -467,7 +467,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._contact_auto_mode_value
 
     @contact_auto_mode_value.setter
-    def contact_auto_mode_value(self, contact_auto_mode_value):
+    def contact_auto_mode_value(self, contact_auto_mode_value: bool) -> None:
         self._contact_auto_mode_value = contact_auto_mode_value
 
     @property
@@ -475,7 +475,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._wind_auto_mode_value
 
     @wind_auto_mode_value.setter
-    def wind_auto_mode_value(self, wind_auto_mode_value):
+    def wind_auto_mode_value(self, wind_auto_mode_value: bool) -> None:
         self._wind_auto_mode_value = wind_auto_mode_value
 
     @property
@@ -483,7 +483,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._dawn_auto_mode_value
 
     @dawn_auto_mode_value.setter
-    def dawn_auto_mode_value(self, dawn_auto_mode_value):
+    def dawn_auto_mode_value(self, dawn_auto_mode_value: bool) -> None:
         self._dawn_auto_mode_value = dawn_auto_mode_value
 
     @property
@@ -491,7 +491,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._dusk_auto_mode_value
 
     @dusk_auto_mode_value.setter
-    def dusk_auto_mode_value(self, dusk_auto_mode_value):
+    def dusk_auto_mode_value(self, dusk_auto_mode_value: bool) -> None:
         self._dusk_auto_mode_value = dusk_auto_mode_value
 
     @property
@@ -499,7 +499,7 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._rain_auto_mode_value
 
     @rain_auto_mode_value.setter
-    def rain_auto_mode_value(self, rain_auto_mode_value):
+    def rain_auto_mode_value(self, rain_auto_mode_value: bool) -> None:
         self._rain_auto_mode_value = rain_auto_mode_value
 
     @property
@@ -507,5 +507,5 @@ class HomePilotAutoConfigDevice(HomePilotDevice):
         return self._sun_auto_mode_value
 
     @sun_auto_mode_value.setter
-    def sun_auto_mode_value(self, sun_auto_mode_value):
+    def sun_auto_mode_value(self, sun_auto_mode_value: bool) -> None:
         self._sun_auto_mode_value = sun_auto_mode_value

--- a/homepilot/hub.py
+++ b/homepilot/hub.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from typing import Any, Dict
 from .api import HomePilotApi
 from .const import (
     APICAP_DEVICE_TYPE_LOC,
@@ -104,7 +105,7 @@ class HomePilotHub(HomePilotDevice):
             ]
         }
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         self.available = True
         self.fw_update_available = (
             state["status"]["update_status"] != "NO_UPDATE_AVAILABLE"
@@ -151,83 +152,83 @@ class HomePilotHub(HomePilotDevice):
         await self.api.async_update_firmware()
 
     @property
-    def hub_type(self):
+    def hub_type(self) -> str:
         return self._hub_type
 
     @property
-    def fw_version(self):
+    def fw_version(self) -> str:
         return self._fw_version
 
     @fw_version.setter
-    def fw_version(self, fw_version):
+    def fw_version(self, fw_version: str) -> None:
         self._fw_version = fw_version
 
     @property
-    def nodename(self):
+    def nodename(self) -> str:
         return self._nodename
 
     @property
-    def hw_platform(self):
+    def hw_platform(self) -> str:
         return self._hw_platform
 
     @property
-    def sw_platform(self):
+    def sw_platform(self) -> str:
         return self._sw_platform
 
     @property
-    def duofern_stick_version(self):
+    def duofern_stick_version(self) -> str:
         return self._duofern_stick_version
 
     @property
-    def fw_update_available(self):
+    def fw_update_available(self) -> bool:
         return self._fw_update_available
 
     @fw_update_available.setter
-    def fw_update_available(self, fw_update_available):
+    def fw_update_available(self, fw_update_available: bool) -> None:
         self._fw_update_available = fw_update_available
 
     @property
-    def release_notes(self):
+    def release_notes(self) -> str:
         return self._release_notes
 
     @release_notes.setter
-    def release_notes(self, release_notes):
+    def release_notes(self, release_notes: str) -> None:
         self._release_notes = release_notes
 
     @property
-    def download_progress(self):
+    def download_progress(self) -> int | bool:
         return self._download_progress
 
     @download_progress.setter
-    def download_progress(self, download_progress):
+    def download_progress(self, download_progress: int | bool) -> None:
         self._download_progress = download_progress
 
     @property
-    def auto_update(self):
+    def auto_update(self) -> bool:
         return self._auto_update
 
     @auto_update.setter
-    def auto_update(self, auto_update):
+    def auto_update(self, auto_update: bool) -> None:
         self._auto_update = auto_update
 
     @property
-    def fw_update_version(self):
+    def fw_update_version(self) -> str:
         return self._fw_update_version
 
     @fw_update_version.setter
-    def fw_update_version(self, fw_update_version):
+    def fw_update_version(self, fw_update_version: str) -> None:
         self._fw_update_version = fw_update_version
 
     @property
-    def led_status(self):
+    def led_status(self) -> bool:
         return self._led_status
 
     @led_status.setter
-    def led_status(self, led_status):
+    def led_status(self, led_status: bool) -> None:
         self._led_status = led_status
 
     @property
-    def extra_attributes(self):
+    def extra_attributes(self) -> Dict[str, Any]:
         extra_attributes = {
             "HW Platform": self.hw_platform,
             "SW Platform": self.sw_platform,

--- a/homepilot/light.py
+++ b/homepilot/light.py
@@ -26,13 +26,13 @@ class HomePilotLight(HomePilotAutoConfigDevice):
     _b_value: int
     _has_color_temp: bool
     _color_temp_value: int
-    _has_color_mode: int
-    _color_mode: str
+    _has_color_mode: bool
+    _color_mode_value: str
 
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -91,7 +91,7 @@ class HomePilotLight(HomePilotAutoConfigDevice):
             device_map=device_map,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         self.is_on = state["statusesMap"]["Position"] != 0
         self.brightness = state["statusesMap"]["Position"]
@@ -100,7 +100,7 @@ class HomePilotLight(HomePilotAutoConfigDevice):
             self.g_value: int = int(state["statusesMap"]["rgb"].lower()[4:6], 16)
             self.b_value: int = int(state["statusesMap"]["rgb"].lower()[6:8], 16)
         self.color_temp_value = state["statusesMap"]["colortemperature"] if self.has_color_temp else 0
-        self.color_mode_value = state["statusesMap"]["colormode"] if self.has_color_mode else 0
+        self.color_mode_value = state["statusesMap"]["colormode"] if self.has_color_mode else ""
         device = await api.get_device(self.did)
         device_map = HomePilotDevice.get_capabilities_map(device)
         await super().update_device_state(state, device_map)
@@ -110,7 +110,7 @@ class HomePilotLight(HomePilotAutoConfigDevice):
         return self._is_on
 
     @is_on.setter
-    def is_on(self, is_on):
+    def is_on(self, is_on: bool) -> None:
         self._is_on = is_on
 
     @property
@@ -118,19 +118,19 @@ class HomePilotLight(HomePilotAutoConfigDevice):
         return self._brightness
 
     @brightness.setter
-    def brightness(self, brightness):
+    def brightness(self, brightness: int) -> None:
         self._brightness = brightness
 
     @property
-    def has_rgb(self) -> int:
+    def has_rgb(self) -> bool:
         return self._has_rgb
 
     @property
-    def has_color_temp(self) -> int:
+    def has_color_temp(self) -> bool:
         return self._has_color_temp
 
     @property
-    def has_color_mode(self) -> int:
+    def has_color_mode(self) -> bool:
         return self._has_color_mode
 
     @property
@@ -138,7 +138,7 @@ class HomePilotLight(HomePilotAutoConfigDevice):
         return self._r_value
 
     @r_value.setter
-    def r_value(self, r_value):
+    def r_value(self, r_value: int) -> None:
         self._r_value = r_value
 
     @property
@@ -146,7 +146,7 @@ class HomePilotLight(HomePilotAutoConfigDevice):
         return self._g_value
 
     @g_value.setter
-    def g_value(self, g_value):
+    def g_value(self, g_value: int) -> None:
         self._g_value = g_value
 
     @property
@@ -154,7 +154,7 @@ class HomePilotLight(HomePilotAutoConfigDevice):
         return self._b_value
 
     @b_value.setter
-    def b_value(self, b_value):
+    def b_value(self, b_value: int) -> None:
         self._b_value = b_value
 
     @property
@@ -162,15 +162,15 @@ class HomePilotLight(HomePilotAutoConfigDevice):
         return self._color_temp_value
 
     @color_temp_value.setter
-    def color_temp_value(self, color_temp_value):
+    def color_temp_value(self, color_temp_value: int) -> None:
         self._color_temp_value = color_temp_value
 
     @property
-    def color_mode_value(self) -> int:
+    def color_mode_value(self) -> str:
         return self._color_mode_value
 
     @color_mode_value.setter
-    def color_mode_value(self, color_mode_value):
+    def color_mode_value(self, color_mode_value: str) -> None:
         self._color_mode_value = color_mode_value
 
     async def async_turn_on(self) -> None:
@@ -179,14 +179,14 @@ class HomePilotLight(HomePilotAutoConfigDevice):
     async def async_turn_off(self) -> None:
         await self.api.async_turn_off(self.did)
 
-    async def async_set_brightness(self, new_brightness) -> None:
+    async def async_set_brightness(self, new_brightness: int) -> None:
         await self.api.async_set_position(self.did, new_brightness)
 
-    async def async_set_rgb(self, r, g, b) -> None:
+    async def async_set_rgb(self, r: int, g: int, b: int) -> None:
         new_rgb: str = f"0x{(r * pow(2, 16) + g * pow(2, 8) + b):06X}"
         await self.api.async_set_rgb(self.did, new_rgb)
 
-    async def async_set_color_temp(self, new_color_temp) -> None:
+    async def async_set_color_temp(self, new_color_temp: int) -> None:
         await self.api.async_set_color_temp(self.did, new_color_temp)
 
     async def async_toggle(self) -> None:

--- a/homepilot/manager.py
+++ b/homepilot/manager.py
@@ -101,7 +101,7 @@ class HomePilotManager:
             "led": await self.api.async_get_led_status(),
         }
 
-    async def update_state(self, did):
+    async def update_state(self, did: str):
         try:
             if did == "-1":
                 state = await self.get_hub_state()

--- a/homepilot/scenes.py
+++ b/homepilot/scenes.py
@@ -17,7 +17,7 @@ class HomePilotScene:
     """HomePilot Scene"""
 
     _api: HomePilotApi
-    _sid: int
+    _sid: str
     _name: str
     _description: str
     _is_enabled: bool
@@ -27,13 +27,15 @@ class HomePilotScene:
     def __init__(
         self,
         api: HomePilotApi,
-        sid: int,
+        sid: str,
         name: str,
         description: str,
         is_enabled: bool = False,
         is_manual_executable: bool = False,
     ) -> None:
         self._api = api
+        # sid is already a str: the API layer normalizes scene ids on read
+        # (see HomePilotApi._normalize_scene_ids), so it is consistent with device ids.
         self._sid = sid
         self._name = name
         self._description = description
@@ -57,7 +59,7 @@ class HomePilotScene:
             is_manual_executable=bool(scene_data.get("is_manual_executable", 0)),
         )
 
-    async def async_update_scene(self, scene) -> None:
+    async def async_update_scene(self, scene: Dict[str, Any]) -> None:
         self.name = scene["name"]
         self.description = scene["description"]
         self.is_enabled = bool(scene["is_enabled"])
@@ -88,7 +90,7 @@ class HomePilotScene:
         return self._api
 
     @property
-    def sid(self) -> int:
+    def sid(self) -> str:
         return self._sid
 
     @property
@@ -104,7 +106,7 @@ class HomePilotScene:
         return self._available
 
     @available.setter
-    def available(self, available):
+    def available(self, available: bool) -> None:
         self._available = available
 
     @property

--- a/homepilot/sensor.py
+++ b/homepilot/sensor.py
@@ -1,5 +1,6 @@
 import asyncio
 from enum import Enum
+from typing import Any, Dict
 from .const import (
     APICAP_BATTERY_LVL_PCT_MEA,
     APICAP_CLOSE_CONTACT_MEA,
@@ -55,7 +56,7 @@ class HomePilotSensor(HomePilotDevice):
     _has_contact_state: bool
     _contact_state_value: ContactState
     _has_battery_level: bool
-    _battery_level_value: float
+    _battery_level_value: int
     _has_motion_detection: bool
     _motion_detection_value: bool
     _has_smoke_detection: bool
@@ -64,7 +65,7 @@ class HomePilotSensor(HomePilotDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -150,7 +151,7 @@ class HomePilotSensor(HomePilotDevice):
             has_smoke_detection=APICAP_SMOKE_DETECTION_MEA in device_map,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         if self.has_temperature and "temperature_primary" in state["readings"]:
             self.temperature_value = state["readings"]["temperature_primary"]
@@ -244,7 +245,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._temperature_value
 
     @temperature_value.setter
-    def temperature_value(self, temperature_value):
+    def temperature_value(self, temperature_value: float) -> None:
         self._temperature_value = temperature_value
 
     @property
@@ -252,7 +253,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._target_temperature_value
 
     @target_temperature_value.setter
-    def target_temperature_value(self, target_temperature_value):
+    def target_temperature_value(self, target_temperature_value: float) -> None:
         self._target_temperature_value = target_temperature_value
 
     @property
@@ -260,7 +261,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._wind_speed_value
 
     @wind_speed_value.setter
-    def wind_speed_value(self, wind_speed_value):
+    def wind_speed_value(self, wind_speed_value: float) -> None:
         self._wind_speed_value = wind_speed_value
 
     @property
@@ -268,7 +269,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._wind_detection_value
 
     @wind_detection_value.setter
-    def wind_detection_value(self, wind_detection_value):
+    def wind_detection_value(self, wind_detection_value: bool) -> None:
         self._wind_detection_value = wind_detection_value
 
     @property
@@ -276,7 +277,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._brightness_value
 
     @brightness_value.setter
-    def brightness_value(self, brightness_value):
+    def brightness_value(self, brightness_value: float) -> None:
         self._brightness_value = brightness_value
 
     @property
@@ -284,7 +285,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._sun_height_value
 
     @sun_height_value.setter
-    def sun_height_value(self, sun_height_value):
+    def sun_height_value(self, sun_height_value: float) -> None:
         self._sun_height_value = sun_height_value
 
     @property
@@ -292,7 +293,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._sun_direction_value
 
     @sun_direction_value.setter
-    def sun_direction_value(self, sun_direction_value):
+    def sun_direction_value(self, sun_direction_value: float) -> None:
         self._sun_direction_value = sun_direction_value
 
     @property
@@ -300,7 +301,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._rain_detection_value
 
     @rain_detection_value.setter
-    def rain_detection_value(self, rain_detection_value):
+    def rain_detection_value(self, rain_detection_value: bool) -> None:
         self._rain_detection_value = rain_detection_value
 
     @property
@@ -308,7 +309,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._sun_detection_value
 
     @sun_detection_value.setter
-    def sun_detection_value(self, sun_detection_value):
+    def sun_detection_value(self, sun_detection_value: bool) -> None:
         self._sun_detection_value = sun_detection_value
 
     @property
@@ -316,15 +317,15 @@ class HomePilotSensor(HomePilotDevice):
         return self._contact_state_value
 
     @contact_state_value.setter
-    def contact_state_value(self, contact_state_value):
+    def contact_state_value(self, contact_state_value: ContactState) -> None:
         self._contact_state_value = contact_state_value
 
     @property
-    def battery_level_value(self) -> float:
+    def battery_level_value(self) -> int:
         return self._battery_level_value
 
     @battery_level_value.setter
-    def battery_level_value(self, battery_level_value):
+    def battery_level_value(self, battery_level_value: int) -> None:
         self._battery_level_value = battery_level_value
 
     @property
@@ -332,7 +333,7 @@ class HomePilotSensor(HomePilotDevice):
         return self._motion_detection_value
 
     @motion_detection_value.setter
-    def motion_detection_value(self, motion_detection_value):
+    def motion_detection_value(self, motion_detection_value: bool) -> None:
         self._motion_detection_value = motion_detection_value
 
     @property
@@ -340,5 +341,5 @@ class HomePilotSensor(HomePilotDevice):
         return self._smoke_detection_value
 
     @smoke_detection_value.setter
-    def smoke_detection_value(self, smoke_detection_value):
+    def smoke_detection_value(self, smoke_detection_value: bool) -> None:
         self._smoke_detection_value = smoke_detection_value

--- a/homepilot/switch.py
+++ b/homepilot/switch.py
@@ -20,7 +20,7 @@ class HomePilotSwitch(HomePilotAutoConfigDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -70,7 +70,7 @@ class HomePilotSwitch(HomePilotAutoConfigDevice):
             device_map=device_map,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         self.is_on = state["statusesMap"]["Position"] != 0
         device = await api.get_device(self.did)
@@ -82,7 +82,7 @@ class HomePilotSwitch(HomePilotAutoConfigDevice):
         return self._is_on
 
     @is_on.setter
-    def is_on(self, is_on):
+    def is_on(self, is_on: bool) -> None:
         self._is_on = is_on
 
     async def async_turn_on(self) -> None:

--- a/homepilot/thermostat.py
+++ b/homepilot/thermostat.py
@@ -34,9 +34,9 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
     _step_target_temperature: float
     _can_set_target_temperature: bool
     _has_battery_level: bool
-    _battery_level_value: float
+    _battery_level_value: int
     _has_relais_status: bool
-    _relais_status: float
+    _relais_status: bool
     _has_temperature_thresh_cfg: List[bool | None]
     _temperature_thresh_cfg_value: List[float | None]
     _temperature_thresh_cfg_min: List[float | None]
@@ -55,7 +55,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -177,7 +177,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
             device_map=device_map,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         if self.has_temperature:
             self.temperature_value = state["statusesMap"]["acttemperatur"] / 10
@@ -186,7 +186,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         if self.has_battery_level and "batteryStatus" in state:
             self.battery_level_value = state["batteryStatus"]
         if self.has_relais_status:
-            self.relais_status = state["statusesMap"]["relaisstatus"]
+            self.relais_status = state["statusesMap"]["relaisstatus"] == 1
         device_map = HomePilotDevice.get_capabilities_map(await self.api.get_device(self.did))
         await super().update_device_state(state, device_map)
         # Update new window detection and boost properties from device_map
@@ -213,16 +213,16 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         if self.has_boost_active:
             self.boost_active_value = device_map[APICAP_BOOST_ACTIVE_CFG]["value"] == "true"
 
-    async def async_set_target_temperature(self, temperature) -> None:
+    async def async_set_target_temperature(self, temperature: float) -> None:
         await self.api.async_set_target_temperature(self.did, temperature)
 
-    async def async_set_temperature_thresh_cfg(self, thresh_number, temperature) -> None:
+    async def async_set_temperature_thresh_cfg(self, thresh_number: int, temperature: float) -> None:
         await self.api.async_set_temperature_thresh_cfg(self.did, thresh_number, temperature)
 
-    async def async_set_boost_active_cfg(self, boost_active) -> None:
+    async def async_set_boost_active_cfg(self, boost_active: bool) -> None:
         await self.api.async_set_boost_active_cfg(self.did, boost_active)
 
-    async def async_set_boost_time_cfg(self, boost_time) -> None:
+    async def async_set_boost_time_cfg(self, boost_time: float) -> None:
         await self.api.async_set_boost_time_cfg(self.did, boost_time)
 
     @property
@@ -290,7 +290,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         return self._temperature_value
 
     @temperature_value.setter
-    def temperature_value(self, temperature_value):
+    def temperature_value(self, temperature_value: float) -> None:
         self._temperature_value = temperature_value
 
     @property
@@ -298,23 +298,23 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         return self._target_temperature_value
 
     @target_temperature_value.setter
-    def target_temperature_value(self, target_temperature_value):
+    def target_temperature_value(self, target_temperature_value: float) -> None:
         self._target_temperature_value = target_temperature_value
 
     @property
-    def battery_level_value(self) -> float:
+    def battery_level_value(self) -> int:
         return self._battery_level_value
 
     @battery_level_value.setter
-    def battery_level_value(self, battery_level_value):
+    def battery_level_value(self, battery_level_value: int) -> None:
         self._battery_level_value = battery_level_value
 
     @property
-    def relais_status(self) -> float:
+    def relais_status(self) -> bool:
         return self._relais_status
 
     @relais_status.setter
-    def relais_status(self, relais_status):
+    def relais_status(self, relais_status: bool) -> None:
         self._relais_status = relais_status
 
     # New window detection and boost properties
@@ -327,7 +327,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         return self._ext_open_window_detect_value
 
     @ext_open_window_detect_value.setter
-    def ext_open_window_detect_value(self, ext_open_window_detect_value):
+    def ext_open_window_detect_value(self, ext_open_window_detect_value: bool) -> None:
         self._ext_open_window_detect_value = ext_open_window_detect_value
 
     @property
@@ -339,7 +339,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         return self._int_open_window_detect_value
 
     @int_open_window_detect_value.setter
-    def int_open_window_detect_value(self, int_open_window_detect_value):
+    def int_open_window_detect_value(self, int_open_window_detect_value: bool) -> None:
         self._int_open_window_detect_value = int_open_window_detect_value
 
     @property
@@ -351,7 +351,7 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         return self._boost_time_value
 
     @boost_time_value.setter
-    def boost_time_value(self, boost_time_value):
+    def boost_time_value(self, boost_time_value: float) -> None:
         self._boost_time_value = boost_time_value
 
     @property
@@ -363,5 +363,5 @@ class HomePilotThermostat(HomePilotAutoConfigDevice):
         return self._boost_active_value
 
     @boost_active_value.setter
-    def boost_active_value(self, boost_active_value):
+    def boost_active_value(self, boost_active_value: bool) -> None:
         self._boost_active_value = boost_active_value

--- a/homepilot/wallcontroller.py
+++ b/homepilot/wallcontroller.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, Dict
 
 from .const import (
     APICAP_DEVICE_TYPE_LOC,
@@ -22,7 +23,7 @@ class HomePilotWallController(HomePilotDevice):
     def __init__(
         self,
         api: HomePilotApi,
-        did: int,
+        did: str,
         uid: str,
         name: str,
         device_number: str,
@@ -81,7 +82,7 @@ class HomePilotWallController(HomePilotDevice):
             channels=channels,
         )
 
-    async def update_state(self, state, api):
+    async def update_state(self, state: Dict[str, Any], api: HomePilotApi):
         await super().update_state(state, api)
         if self.has_battery_low and "batteryLow" in state:
             self.battery_low_value = state["batteryLow"]
@@ -97,7 +98,7 @@ class HomePilotWallController(HomePilotDevice):
                 self._channels[i] = device_map[f"KEY_PUSH_CH{i}_EVT"]["timestamp"]
 
     @property
-    def channels(self):
+    def channels(self) -> dict:
         return self._channels
 
     @property
@@ -109,5 +110,5 @@ class HomePilotWallController(HomePilotDevice):
         return self._battery_low_value
 
     @battery_low_value.setter
-    def battery_low_value(self, battery_low_value):
+    def battery_low_value(self, battery_low_value: bool) -> None:
         self._battery_low_value = battery_low_value

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyrademacher",
-    version="0.16.0",
+    version="0.17.0",
     author="Pedro Ribeiro",
     author_email="pedroeusebio@gmail.com",
     description="Control devices connected to your Rademacher Homepilot "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -215,6 +215,35 @@ class TestHomePilotApi:
                         "3": {"did": "3", "name": "name3"}}
             assert await instance.async_get_devices_state() == expected
 
+    @pytest.mark.asyncio
+    async def test_async_get_scenes_normalizes_ids_to_str(self):
+        # The bridge returns scene ids as raw JSON numbers; the API layer must
+        # normalize them to str so they are consistent with device ids.
+        with aioresponses() as mocked:
+            instance: HomePilotApi = HomePilotApi(TEST_HOST, "")
+            mocked.get(
+                f"http://{TEST_HOST}/scenes",
+                status=200,
+                body=json.dumps({"scenes": [{"id": 1, "name": "a"},
+                                            {"id": 8001, "name": "b"}]})
+            )
+            scenes = await instance.async_get_scenes()
+            assert [s["id"] for s in scenes] == ["1", "8001"]
+            assert all(isinstance(s["id"], str) for s in scenes)
+
+    @pytest.mark.asyncio
+    async def test_async_get_scenes_v4_normalizes_ids_to_str(self):
+        with aioresponses() as mocked:
+            instance: HomePilotApi = HomePilotApi(TEST_HOST, "")
+            mocked.get(
+                f"http://{TEST_HOST}/v4/scenes",
+                status=200,
+                body=json.dumps({"scenes": [{"id": 42, "name": "c"}]})
+            )
+            scenes = await instance.async_get_scenes_v4()
+            assert scenes[0]["id"] == "42"
+            assert isinstance(scenes[0]["id"], str)
+
     def callback_ping(self, url, **kwargs):
         response = {"error_code": 0, "error_description": "OK", "payload": {}}
         return CallbackResult(
@@ -408,6 +437,27 @@ class TestHomePilotApi:
             )
             result = await instance.async_contact_close_cmd(did)
             assert result["error_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_send_device_command_omits_value_when_none(self):
+        # Pure command capabilities (e.g. SUN_START_CMD) must be sent as {"name": ...}
+        # WITHOUT a "value": null, which the bridge mis-interprets. Value-carrying
+        # commands must still include the value.
+        did = "1"
+        seen = []
+
+        def cb(url, **kwargs):
+            seen.append(kwargs["json"])
+            return CallbackResult(body=json.dumps({"error_code": 0}))
+
+        with aioresponses() as mocked:
+            instance: HomePilotApi = HomePilotApi(TEST_HOST, "")
+            mocked.put(f"http://{TEST_HOST}/devices/{did}", callback=cb, repeat=True)
+            await instance.async_sun_start_cmd(did)         # value None -> omit
+            await instance.async_set_auto_mode(did, True)   # value given -> include
+            assert "value" not in seen[0]
+            assert seen[0]["name"] == "SUN_START_CMD"
+            assert seen[1]["value"] is True
 
     @pytest.mark.asyncio
     async def test_async_set_boost_active_cfg(self):

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -91,7 +91,7 @@ class TestHomePilotThermostat:
         }, mocked_api)
         assert thermostat.temperature_value == 21.2
         assert thermostat.target_temperature_value == 24.0
-        assert thermostat.relais_status == 1
+        assert thermostat.relais_status is True
         assert thermostat.ext_open_window_detect_value is False
         assert thermostat.int_open_window_detect_value is True
         assert thermostat.boost_time_value == 30.0


### PR DESCRIPTION
# Fix bridge write payloads (scene ids, null command value) + consistent type annotations

_Base:_ `peribeir/pyrademacher:master` · _Head:_ `MrTomRocker:fix/standardize-ids-as-str`

## Summary

Two functional bugfixes at the API layer, plus a pass that makes the type
annotations match the actual runtime types (which also surfaced the two bugs).

The bridge's HTTP API is inconsistent about types: capability values are **always
strings** on read (`"63"`, `"true"`, `"20.43"`), scene ids come back as raw JSON
**numbers**, and some writes are accepted as numbers while others need strings.
This PR normalizes those quirks in one place (the API layer) so the rest of the
library can rely on consistent Python types.

## Functional fixes

### 1. Scene ids normalized to `str` (root cause of homeassistant-rademacher#176)
`/scenes` returns the scene id as a raw number, so `scene.sid` was an `int` and
`manager.scenes` was int-keyed — while device ids (`device.did`, from capability
values) are strings. The integration's "ids as strings" handling then mismatched
the int-keyed scene dict, leaving scene entities `unavailable`.

Fix: `async_get_scenes` / `async_get_scenes_v4` normalize the id to `str`
(`_normalize_scene_ids`). Scene ids are now `str` end-to-end (`scene.sid`,
`manager.scenes` keys), consistent with device ids.

### 2. Pure command capabilities no longer send `"value": null`
Command capabilities (`SUN_START_CMD`, `SUN_STOP_CMD`, `WIND_*`, `RAIN_*`,
`GOTO_DAWN/DUSK_POS_CMD`, `CONTACT_OPEN/CLOSE_CMD`) have **no value** on the bridge
(`timestamp: -1`, no `value` field). They were sent via
`async_send_device_command(did, cmd, None)`, producing
`{"name": cmd, "value": null}`. The bridge mis-handles that extra `null` — e.g. a
`SUN_START` was acted on even when the sun auto mode was disabled.

Fix: `async_send_device_command` only includes `"value"` when one is given:
```python
body = {"name": command}
if value is not None:
    body["value"] = value
```
The working pure commands (ping / open / close / stop / turn_on/off) already send
`{"name": cmd}`; the weather/contact/goto commands now match. Value-carrying calls
(`auto_mode=False`, `boost=0`, …) are unaffected (`is not None` keeps `False`/`0`).

## Type annotations

`__init__` parameters were typed but properties, setters and most `async`
signatures were not. This pass closes that gap and fixes annotations that did not
match runtime, verified against real bridge payloads:

- `did: int` → `did: str` across all device classes (capability ids are strings).
- Return/param types added to all properties, setters and `async` methods.
- Corrected against bridge reality:
  - `light`: `has_rgb` / `has_color_temp` / `has_color_mode` → `bool`;
    `color_mode_value` → `str` (bridge sends `"ct"`/`"hs"`; the consumer already
    compares `== "ct"`).
  - `thermostat`: `relais_status` → `bool` (bridge `relaisstatus` is `0/1`, now
    mapped); `battery_level_value` → `int`.
  - `sensor`: `battery_level_value` → `int`.

Annotations are descriptive only and don't change runtime, except the two small
read-side consistency tweaks above (`relais_status` 0/1→bool, `color_mode_value`
empty fallback `0`→`""`).

> Note: `async_set_ventilation_position` intentionally keeps sending a **string**
> (`VENTIL_POS_CFG` is a config capability the bridge may expect as a string), unlike
> the state-based positions (`GOTO_POS_CMD`/`SET_SLAT_POS_CMD`) which are ints. I could
> not verify this, so no runtime change was made here.

## Testing

- Full suite: **145 passed** (python:3.12-slim, `pytest-asyncio==0.21.2`,
  `aioresponses`). New tests: scene-id normalization (`async_get_scenes[_v4]`),
  and `async_send_device_command` omitting `value` when `None`.
- `flake8` (`E9,F63,F7,F82,F401,F811`): **0**.

## Version
`0.16.0 → 0.17.0` (scene id runtime type changes; command payload change).
